### PR TITLE
Add WildLayout and top nav bar

### DIFF
--- a/src/nextjs-front/components/TopNavBar.tsx
+++ b/src/nextjs-front/components/TopNavBar.tsx
@@ -1,0 +1,38 @@
+import Link from "next/link";
+import { NavItem } from "../constants/nav";
+import Image from "next/image";
+
+type TopNavBarProps = {
+	items: NavItem[];
+};
+
+const TopNavBar: React.FC<TopNavBarProps> = ({ items }) => {
+	return (
+		<header className="fixed top-0 left-0 right-0 flex items-center justify-between h-32 px-24 text-white">
+			<div className="flex items-center gap-x-16">
+				<Link href="/"><a><Image src="/logo.svg" height={70} width={70} /></a></Link>
+				<nav>
+					<ul className="flex gap-x-16">
+						{items.map((item) => (
+							<li
+								key={item.id}
+								className="uppercase hover:text-pink-600"
+							>
+								<Link href={item.href}>
+									<a>{item.label}</a>
+								</Link>
+							</li>
+						))}
+					</ul>
+				</nav>
+			</div>
+			<Link href="/signin">
+				<a className="px-8 py-2 font-bold uppercase bg-pink-600">
+					Play
+				</a>
+			</Link>
+		</header>
+	);
+};
+
+export default TopNavBar;

--- a/src/nextjs-front/components/WildLayout.tsx
+++ b/src/nextjs-front/components/WildLayout.tsx
@@ -1,0 +1,12 @@
+import { Fragment } from "react";
+import { wildNavItems } from "../constants/nav";
+import TopNavBar from "./TopNavBar";
+
+const WildLayout: React.FC<{}> = ({ children }) => (
+	<Fragment>
+		<TopNavBar items={wildNavItems} />
+		{children}
+	</Fragment>
+);
+
+export default WildLayout;

--- a/src/nextjs-front/components/hoc/withWildLayout.tsx
+++ b/src/nextjs-front/components/hoc/withWildLayout.tsx
@@ -1,0 +1,11 @@
+import WildLayout from '../WildLayout';
+
+const withWildLayout = (Component: React.FC) => {
+	return () => (
+		<WildLayout>
+			<Component />
+		</WildLayout>
+	)
+}
+
+export default withWildLayout;

--- a/src/nextjs-front/constants/nav.ts
+++ b/src/nextjs-front/constants/nav.ts
@@ -1,0 +1,23 @@
+export type NavItem = {
+	id: number,
+	label: string;
+	href: string;
+};
+
+export const wildNavItems: NavItem[] = [
+	{
+		id: 0,
+		label: 'Discover',
+		href: '/#discover',
+	},
+	{
+		id: 1,
+		label: 'Features',
+		href: '/#features',
+	},
+	{
+		id: 2,
+		label: 'The team',
+		href: '/#team',
+	}
+];

--- a/src/nextjs-front/pages/home.tsx
+++ b/src/nextjs-front/pages/home.tsx
@@ -1,0 +1,7 @@
+import withWildLayout from "../components/hoc/withWildLayout";
+
+const HomePage: React.FC = () => {
+  return <div className="min-h-screen bg-gray-900"></div>;
+};
+
+export default withWildLayout(HomePage);

--- a/src/nextjs-front/public/logo.svg
+++ b/src/nextjs-front/public/logo.svg
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Generator: Adobe Illustrator 18.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+
+<svg
+   version="1.1"
+   id="Calque_1"
+   x="0px"
+   y="0px"
+   viewBox="0 -200 960 960"
+   enable-background="new 0 -200 960 960"
+   xml:space="preserve"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><defs
+   id="defs9" />
+<polygon
+   id="polygon5"
+   points="32,412.6 362.1,412.6 362.1,578 526.8,578 526.8,279.1 197.3,279.1 526.8,-51.1 362.1,-51.1   32,279.1 "
+   style="fill:#db2777;fill-opacity:1" />
+<polygon
+   id="polygon7"
+   points="597.9,114.2 762.7,-51.1 597.9,-51.1 "
+   style="fill:#db2777;fill-opacity:1" />
+<polygon
+   id="polygon9"
+   points="762.7,114.2 597.9,279.1 597.9,443.9 762.7,443.9 762.7,279.1 928,114.2 928,-51.1 762.7,-51.1 "
+   style="fill:#db2777;fill-opacity:1" />
+<polygon
+   id="polygon11"
+   points="928,279.1 762.7,443.9 928,443.9 "
+   style="fill:#db2777;fill-opacity:1" />
+</svg>


### PR DESCRIPTION
 - Add `WildLayout` which is supposed to wrap any Next page outside of the user's dashboard interface.
 - `WildLayout` features the `TopNavBar` component which is well... A navigation menu fixed at the top of the screen.
 - Add `withWildLayout` [High Order Component](https://fr.reactjs.org/docs/higher-order-components.html) to easily apply wildLayout to any page
 
For example:
 ```tsx
 export defaut withWildLayout(MyPage);
 ```

**No responsive support yet.**
**Missing footer.**
