### PR TITLE
Display user status

### DIFF
--- a/src/nestjs-back/src/chat/chat.gateway.ts
+++ b/src/nestjs-back/src/chat/chat.gateway.ts
@@ -506,22 +506,21 @@ export class ChatGateway implements OnGatewayInit, OnGatewayConnection {
 	) {
 		try {
 			let dm = await this.chatService.checkIfDmExists(data);
-			const roomId = `dm_${dm.id}`;
 
 			if (!dm) {
 				dm = await this.chatService.createDm(data);
 
-				const userId = this.chatUsers.getUser(client.id).id;
-				const friend = data.users.find((user) => user.id != userId);
+				const user = this.chatUsers.getUser(client.id);
+				const friend = data.users.find((dmUser) => dmUser.id !== user.id);
 				const friendUser = this.chatUsers.getUserById(friend.id.toString());
 
 				if (friendUser) {
-					this.userJoinRoom(friendUser.socketId, roomId);
+					this.userJoinRoom(friendUser.socketId, `dm_${dm.id}`);
 					this.server.to(friendUser.socketId).emit('updateDm', (dm));
-					this.server.to(friendUser.socketId).emit('invitedInChat', { from: userId });
+					this.server.to(friendUser.socketId).emit('invitedInChat', { from: user.id });
 				}
 			}
-			this.userJoinRoom(client.id, roomId);
+			this.userJoinRoom(client.id, `dm_${dm.id}`);
 			this.server.to(client.id).emit('dmCreated', (dm));
 		} catch (e) {
 			this.server.to(client.id).emit('chatError', e.message);

--- a/src/nestjs-back/src/chat/chat.gateway.ts
+++ b/src/nestjs-back/src/chat/chat.gateway.ts
@@ -505,18 +505,24 @@ export class ChatGateway implements OnGatewayInit, OnGatewayConnection {
 		@MessageBody() data: CreateDirectMessageDto
 	) {
 		try {
-			const dm = await this.chatService.createDm(data);
+			let dm = await this.chatService.checkIfDmExists(data);
 			const roomId = `dm_${dm.id}`;
-			const userId = this.chatUsers.getUser(client.id).id;
-			const friend = data.users.find((user) => user.id != userId);
-			const friendUser = this.chatUsers.getUserById(friend.id.toString());
 
-			this.userJoinRoom(client.id, roomId);
-			this.server.to(roomId).emit('dmCreated', (dm));
-			if (friendUser) {
-				this.userJoinRoom(friendUser.socketId, roomId);
-				this.server.to(friendUser.socketId).emit('updateDm', (dm));
+			if (!dm) {
+				dm = await this.chatService.createDm(data);
+
+				const userId = this.chatUsers.getUser(client.id).id;
+				const friend = data.users.find((user) => user.id != userId);
+				const friendUser = this.chatUsers.getUserById(friend.id.toString());
+
+				if (friendUser) {
+					this.userJoinRoom(friendUser.socketId, roomId);
+					this.server.to(friendUser.socketId).emit('updateDm', (dm));
+					this.server.to(friendUser.socketId).emit('invitedInChat', { from: userId });
+				}
 			}
+			this.userJoinRoom(client.id, roomId);
+			this.server.to(client.id).emit('dmCreated', (dm));
 		} catch (e) {
 			this.server.to(client.id).emit('chatError', e.message);
 		}

--- a/src/nestjs-back/src/chat/chat.gateway.ts
+++ b/src/nestjs-back/src/chat/chat.gateway.ts
@@ -512,10 +512,11 @@ export class ChatGateway implements OnGatewayInit, OnGatewayConnection {
 			const friendUser = this.chatUsers.getUserById(friend.id.toString());
 
 			this.userJoinRoom(client.id, roomId);
-			if (friendUser) {
-				this.server.to(friendUser.socketId).emit('dmCreated', (dm));
-			}
 			this.server.to(roomId).emit('dmCreated', (dm));
+			if (friendUser) {
+				this.userJoinRoom(friendUser.socketId, roomId);
+				this.server.to(friendUser.socketId).emit('updateDm', (dm));
+			}
 		} catch (e) {
 			this.server.to(client.id).emit('chatError', e.message);
 		}

--- a/src/nestjs-back/src/chat/chat.service.ts
+++ b/src/nestjs-back/src/chat/chat.service.ts
@@ -11,6 +11,7 @@ import { UpdateChannelDto } from './channels/dto/update-channel.dto';
 import { CreateChannelMessageDto } from './channels/dto/create-channel-message.dto';
 import { CreateDirectMessageDto } from './direct-messages/dto/create-direct-message.dto';
 import { CreateDmMessageDto } from './direct-messages/dto/create-dm-message.dto';
+import { DirectMessage } from './direct-messages/entities/direct-messages';
 
 @Injectable()
 export class ChatService {
@@ -227,6 +228,18 @@ export class ChatService {
 		const dm = await this.directMessagesService.findOne(dmId.toString());
 
 		return (dm.users[0].id === userId) ? dm.users[1] : dm.users[0];
+	}
+
+	async checkIfDmExists(createDirectMessageDto: CreateDirectMessageDto) {
+		let existingDm: DirectMessage;
+
+		try {
+			existingDm = await this.usersService.getDirectMessage(
+				createDirectMessageDto.users[0].id.toString(),
+				createDirectMessageDto.users[1].id.toString()
+			);
+			return existingDm;
+		} catch (e) {}
 	}
 
 	/* Create/delete/update */

--- a/src/nestjs-back/src/chat/direct-messages/direct-messages.service.ts
+++ b/src/nestjs-back/src/chat/direct-messages/direct-messages.service.ts
@@ -41,22 +41,10 @@ export class DirectMessagesService {
   }
 
   async create(createDirectMessageDto: CreateDirectMessageDto) {
-    let existingDm: DirectMessage;
+    const dm = this.directMessagesRepository.create(createDirectMessageDto);
 
-    try {
-      existingDm = await this.usersService.getDirectMessage(
-        createDirectMessageDto.users[0].id.toString(),
-        createDirectMessageDto.users[1].id.toString()
-      );
-      return existingDm;
-    } catch (e) {
-      if (e instanceof Error) {
-        const dm = this.directMessagesRepository.create(createDirectMessageDto);
-
-        this.logger.log('Create new Direct Message');
-        return this.directMessagesRepository.save(dm);
-      }
-    }
+    this.logger.log('Create new Direct Message');
+    return this.directMessagesRepository.save(dm);
   }
 
   async update(id: string, updateDirectMessageDto: UpdateDirectMessageDto) {

--- a/src/nestjs-back/src/games/class/Constants.ts
+++ b/src/nestjs-back/src/games/class/Constants.ts
@@ -25,10 +25,10 @@ export enum GameState {
 }
 
 export enum UserStatus {
-	OFFLINE,
-	ONLINE,
 	INHUB,
 	INQUEUE,
+	OFFLINE,
+	ONLINE,
+	PLAYING,
 	SPECTATING,
-	PLAYING
 }

--- a/src/nextjs-front/components/UserStatus.tsx
+++ b/src/nextjs-front/components/UserStatus.tsx
@@ -18,15 +18,16 @@ export const UserStatusItem: React.FC<{ status?: UserStatus, withText?: boolean,
 	const updateUserStatusListener = ({ userId, status }: { userId: number, status: UserStatus }) => {
 		console.log('updateUserStatus');
 		if (parseInt(id) !== userId) return ;
+
 		setColor(statusColors[status]);
 		setState(status);
 	}
 
 	useEffect(() => {
+		setColor(statusColors.DEACTIVATED);
 		if (socket) {
 			socket.emit("getUserStatus", { userId: id });
 		}
-		setColor(statusColors.DEACTIVATED);
 	}, [id]);
 
 	useEffect(() => {

--- a/src/nextjs-front/components/UserStatus.tsx
+++ b/src/nextjs-front/components/UserStatus.tsx
@@ -1,20 +1,23 @@
 import { useContext, useEffect, useState } from "react";
 import chatContext, { ChatContextType } from "../context/chat/chatContext";
 
-export type UserStatus = 'ONLINE' | 'OFFLINE' | 'deactivated';
+export type UserStatus = 'DEACTIVATED' | 'OFFLINE' | 'ONLINE' | 'PLAYING';
 
 const statusColors = {
-	'ONLINE': 'bg-green-500',
+	'DEACTIVATED': 'bg-gray-700',
 	'OFFLINE': 'bg-red-500',
-	'deactivated': 'bg-gray-700'
+	'ONLINE': 'bg-green-500',
+	'PLAYING': 'bg-yellow-500',
 };
 
-export const UserStatusItem: React.FC<{ status: UserStatus, withText?: boolean, className?: string, id: string }> = ({ status, withText, className, id }) => {
+export const UserStatusItem: React.FC<{ status?: UserStatus, withText?: boolean, className?: string, id: string }> = ({ status, withText, className, id }) => {
 	const [color, setColor] = useState(className || 'bg-green-500');
 	const [state, setState] = useState(status);
 	const { socket } = useContext(chatContext) as ChatContextType;
 
-	const updateUserStatusListener = (status: UserStatus) => {
+	const updateUserStatusListener = ({ userId, status }: { userId: number, status: UserStatus }) => {
+		console.log('updateUserStatus');
+		if (parseInt(id) !== userId) return ;
 		setColor(statusColors[status]);
 		setState(status);
 	}
@@ -23,7 +26,7 @@ export const UserStatusItem: React.FC<{ status: UserStatus, withText?: boolean, 
 		if (socket) {
 			socket.emit("getUserStatus", { userId: id });
 		}
-		setColor(statusColors.deactivated);
+		setColor(statusColors.DEACTIVATED);
 	}, [id]);
 
 	useEffect(() => {

--- a/src/nextjs-front/components/chat/DirectMessage.tsx
+++ b/src/nextjs-front/components/chat/DirectMessage.tsx
@@ -51,7 +51,6 @@ export const DirectMessageHeader: React.FC<{ viewParams: any }> = ({
 				</Link>{" "}
 				<UserStatusItem
 					withText={false}
-					status="OFFLINE"
 					id={viewParams.friendId}
 				/>
 			</div>

--- a/src/nextjs-front/components/chat/DirectMessageNew.tsx
+++ b/src/nextjs-front/components/chat/DirectMessageNew.tsx
@@ -44,9 +44,8 @@ const DirectMessageNew: React.FC = () => {
 		const searchTerm = term.toLowerCase();
 
 		setFilteredFriends(
-			friends.filter(
-				(friend) =>
-					friend.username.toLowerCase().includes(searchTerm)
+			friends.filter((friend) =>
+				friend.username.toLowerCase().includes(searchTerm)
 			)
 		);
 	};

--- a/src/nextjs-front/components/chat/DirectMessageNew.tsx
+++ b/src/nextjs-front/components/chat/DirectMessageNew.tsx
@@ -92,7 +92,7 @@ const DirectMessageNew: React.FC = () => {
 							src={`/api/users/${friend.id}/photo`}
 							className="object-fill w-full h-full rounded-full"
 						/>
-						<UserStatusItem status="OFFLINE" withText={false} className="absolute bottom-0 right-0 z-50" id={friend.id} />
+						<UserStatusItem withText={false} className="absolute bottom-0 right-0 z-50" id={friend.id} />
 					</div>
 				{friend.username}
 				</div>

--- a/src/nextjs-front/components/chat/DirectMessages.tsx
+++ b/src/nextjs-front/components/chat/DirectMessages.tsx
@@ -145,7 +145,7 @@ const DirectMessages: React.FC<{ viewParams: Object; }> = ({ viewParams }) => {
 							className="relative z-20 flex items-center justify-center w-16 h-16 text-4xl rounded-full"
 						>
 							<img src={dm.friendPic} className="object-fill w-full h-full rounded-full" />
-							<UserStatusItem withText={false} status="OFFLINE" className="absolute bottom-0 right-0 z-50" id={dm.friendId} />
+							<UserStatusItem withText={false} className="absolute bottom-0 right-0 z-50" id={dm.friendId} />
 						</div>
 					</div>
 					<div className="col-span-2">

--- a/src/nextjs-front/components/chat/GroupAdd.tsx
+++ b/src/nextjs-front/components/chat/GroupAdd.tsx
@@ -138,7 +138,7 @@ const GroupAdd: React.FC<{ viewParams: any }> = ({ viewParams }) => {
 							src={`/api/users/${friend.id}/photo`}
 							className="object-fill w-full h-full rounded-full"
 						/>
-						<UserStatusItem status="OFFLINE" withText={false} className="absolute bottom-0 right-0 z-50" id={friend.id} />
+						<UserStatusItem withText={false} className="absolute bottom-0 right-0 z-50" id={friend.id} />
 					</div>
 					{friend.username}
 				</div>

--- a/src/nextjs-front/pages/friends.tsx
+++ b/src/nextjs-front/pages/friends.tsx
@@ -115,7 +115,6 @@ const FriendsPage: NextPageWithLayout = ({}) => {
             <div className="flex flex-col items-center">
               <h1 className="text-2xl text-pink-600">{user.username}</h1>
               <UserStatusItem
-                status="OFFLINE"
                 id={user.id}
               />
             </div>

--- a/src/nextjs-front/pages/hub.tsx
+++ b/src/nextjs-front/pages/hub.tsx
@@ -1,13 +1,14 @@
 import { Fragment, useEffect, useState, useContext } from "react";
 import { io, Socket } from 'socket.io-client';
 import Head from "next/head";
-import withDashboardLayout from "../components/hoc/withDashboardLayout";
-import Canvas from "../components/Canvas";
-import { IRoom, User } from "../gameObjects/GameObject";
-import alertContext, { AlertContextType } from "../context/alert/alertContext";
-import { useSession } from "../hooks/use-session";
-import OngoingGames from "../components/OngoingGames";
 import { NextPageWithLayout } from "./_app";
+import { useSession } from "../hooks/use-session";
+import alertContext, { AlertContextType } from "../context/alert/alertContext";
+import chatContext, { ChatContextType } from "../context/chat/chatContext";
+import Canvas from "../components/Canvas";
+import withDashboardLayout from "../components/hoc/withDashboardLayout";
+import OngoingGames from "../components/OngoingGames";
+import { IRoom, User } from "../gameObjects/GameObject";
 
 let socket: Socket;
 
@@ -18,7 +19,7 @@ const Hub: NextPageWithLayout = () => {
 	const [inQueue, setInQueue] = useState(false);
 	const [room, setRoom] = useState<IRoom | null>(null);
 	const [currentGames, setCurrentGames] = useState<Array<string>>(new Array());
-
+	const { socket: chatSocket } = useContext(chatContext) as ChatContextType;
 
 	let roomData: IRoom;
 	let roomId: string | undefined;
@@ -41,16 +42,15 @@ const Hub: NextPageWithLayout = () => {
 			socket.emit("handleUserConnect", userData);
 
 			socket.on("updateCurrentGames", (newRoomData: Array<string>) => {
-                setCurrentGames(newRoomData);
-            });
-
+				setCurrentGames(newRoomData);
+			});
 
 			socket.on("newRoom", (newRoomData: IRoom) => {
-					socket.emit("joinRoom", newRoomData.roomId);
-					roomData = newRoomData;
-					roomId = newRoomData.roomId;
-					setRoom(roomData);
-					setInQueue(false);
+				socket.emit("joinRoom", newRoomData.roomId);
+				roomData = newRoomData;
+				roomId = newRoomData.roomId;
+				setRoom(roomData);
+				setInQueue(false);
 			});
 
 			socket.on("joinedQueue", (data: IRoom) => {
@@ -66,10 +66,11 @@ const Hub: NextPageWithLayout = () => {
 				setAlert({
 					type: "info",
 					content: "You were removed from Queue"
-				});	
+				});
 			});
 
 			socket.on("joinedRoom", (data: IRoom) => {
+				chatSocket.emit("userGameStatus", { isPlaying: true });
 				setDisplayGame(true);
 				setAlert({
 					type: "info",
@@ -78,6 +79,7 @@ const Hub: NextPageWithLayout = () => {
 			});
 
 			socket.on("leavedRoom", (data: IRoom) => {
+				chatSocket.emit("userGameStatus", { isPlaying: false });
 				roomId = undefined;
 				setDisplayGame(false);
 				setRoom(null);
@@ -85,13 +87,13 @@ const Hub: NextPageWithLayout = () => {
 
 			socket.emit("getCurrentGames");
 		});
-		
+
 	return () => {
 			if (socket)
 			socket.disconnect();
 		}
 	}, []);
-  
+
 	return (
 		<Fragment>
 			<Head>

--- a/src/nextjs-front/pages/users/[id].tsx
+++ b/src/nextjs-front/pages/users/[id].tsx
@@ -362,7 +362,6 @@ const UserProfilePage: NextPageWithLayout = ({}) => {
               </h1>
               <UserStatusItem
                 className={"mt-2"}
-                status="OFFLINE"
                 id={userData.id}
               />
             </div>


### PR DESCRIPTION
Closes: #81 

- Display user status in real time on profile page (`src/nextjs-front/pages/users/[id].tsx`), friends page (`src/nextjs-front/pages/friends.tsx`), chat views:
![Screenshot at 2022-05-14 19-19-08](https://user-images.githubusercontent.com/41596925/168442152-ddccaf80-29a2-46cd-a816-33823c6a72f8.png)
![Screenshot at 2022-05-14 19-12-50](https://user-images.githubusercontent.com/41596925/168441964-9caf9b51-c15b-4c91-9e4a-819122a486cc.png)

- The chat icon becomes blue on new unread messages:
![Screenshot at 2022-05-14 19-13-31](https://user-images.githubusercontent.com/41596925/168441976-16d639f6-727d-4e14-91f1-c63550ec7d24.png)

- Otherwise, it's pink.
![Screenshot at 2022-05-14 19-13-47](https://user-images.githubusercontent.com/41596925/168441986-00021fcc-335a-4936-b682-7d794d769638.png)
